### PR TITLE
fixed calculation of "next holiday" which was shifted by one day.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Deutsch  | English
 Der Adapter startet jeden Tag um Mitternacht. Ein häufigeres Starten ist nicht erforderlich. | The adapter starts daily at midnight. Due to the nature of the subject, no higher frequency is required.
 
 ## Changelog
+### 0.3.4 (2016-11-10)
+* (jens-maus) fixed calculation of "next holiday" which was shifted by one day. Thus on the day before a holiday it already showed the next one.
+
 ### 0.3.3 (2016-11-08)
 * (jens-maus) added advent ѕundays, "Buß- und Bettag" and many more german holidays
 * (jens-maus) code fix (multilingual reference)

--- a/main.js
+++ b/main.js
@@ -145,7 +145,7 @@ function checkHolidays() {
 
     // next holiday
     var duration = 0;
-    day = day - 1; // shift back to "tomorrow", because tomorrow is the next day
+    day = day - 2; // shift back to "today" so that we calculate everything relative to it
     do {
         day = day + 1;
         if (day > 365 + isLeap) day = 1;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.feiertage",
   "description": "Deutsche Feiertage",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "author": "pix",
   "contributors": [
     "pix", "Bluefox", "jens-maus"


### PR DESCRIPTION
The calculation of the "next" day was broken because it already showed the next holiday one day before a current holiday. This fix should correct this.