### PR TITLE
(BuZZy1337) overwrite the hovercolor of tablerows

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -17,6 +17,12 @@
             .adapter-body {
                 overflow: hidden !important;
             }
+            table.highlight > tbody > tr {
+                transition: background-color .25s ease !important;
+            }
+            table.highlight > tbody > tr:hover {
+                background-color: rgba(200, 200, 200, 0.5) !important;
+            }
         </style>
 
         <!-- you have to define 2 functions in the global scope: -->


### PR DESCRIPTION
The original hover-color of the table-rows were too close to the original background-color of the config dialog.
We need to change the hover-color to be a little bit darker then defined in the .css file.